### PR TITLE
Fix Program.create_data() to work with larger datatypes

### DIFF
--- a/ghidralib.py
+++ b/ghidralib.py
@@ -3781,11 +3781,12 @@ class Program(GhidraWrapper):
         :param address: address of the data.
         :param datatype: datatype to use for the data at `address`."""
         typeobj = DataType(datatype)
+        addr = resolve(address)
         try:
-            createData(resolve(address), unwrap(typeobj))
+            createData(addr, unwrap(typeobj))
         except:
-            clearListing(resolve(address))
-            createData(resolve(address), unwrap(typeobj))
+            clearListing(addr, addr.add(len(typeobj) - 1))
+            createData(addr, unwrap(typeobj))
 
     @staticmethod
     def location():  # type: () -> int


### PR DESCRIPTION
This PR fixes a bug where when using the `Program.create_data()` method, only the code unit at the given address is cleared, and not in the whole range defined by the datatype length. This causes problems, for example, when trying to override a larger data range, consisting of several smaller datatypes, with a struct.

The implementation matches the convention used in `write_bytes()` function.