### PR TITLE
fix: Use ReferenceManager for Function xrefs

### DIFF
--- a/ghidralib.py
+++ b/ghidralib.py
@@ -82,7 +82,6 @@ if sys.version_info.major == 2:
         getMonitor,
         createData,
         clearListing,
-        getReferencesTo,
         getInstructionAt,
         getBytes,
         getState,
@@ -138,7 +137,6 @@ else:
     getState = get_current_interpreter().getState
     createData = get_current_interpreter().createData
     clearListing = get_current_interpreter().clearListing
-    getReferencesTo = get_current_interpreter().getReferencesTo
     getInstructionAt = get_current_interpreter().getInstructionAt
     getBytes = get_current_interpreter().getBytes
     getMonitor = get_current_interpreter().getMonitor
@@ -2629,7 +2627,8 @@ class Function(GhidraWrapper, BodyTrait):
     @property
     def xrefs(self):  # type: () -> list[Reference]
         """Get the references to this function."""
-        raw_refs = getReferencesTo(resolve(self.entrypoint))
+        rm = Program.current().getReferenceManager()
+        raw_refs = rm.getReferencesTo(resolve(self.entrypoint))
         return [Reference(raw) for raw in raw_refs]
 
     xrefs_to = xrefs


### PR DESCRIPTION
getReferencesTo API is limited to max 4096 entries. This may result in unexpected behavior. Use recommended ReferenceManager instead.